### PR TITLE
Handle getting hippy/frat outfits correctly when under level 12

### DIFF
--- a/src/tasks/level12.ts
+++ b/src/tasks/level12.ts
@@ -616,7 +616,7 @@ export const WarQuest: Quest = {
         (have($item`beer helmet`) &&
           have($item`distressed denim pants`) &&
           have($item`bejeweled pledge pin`)),
-      do: () => atLevel(12) ? $location`Wartime Hippy Camp` : $location`The Hippy Camp`,
+      do: () => (atLevel(12) ? $location`Wartime Hippy Camp` : $location`The Hippy Camp`),
       limit: { soft: 10 },
       choices: () => {
         return {
@@ -645,7 +645,7 @@ export const WarQuest: Quest = {
         have($item`beer helmet`) &&
         have($item`distressed denim pants`) &&
         have($item`bejeweled pledge pin`),
-      do: () => atLevel(12) ? $location`Wartime Frat House` : $location`The Orcish Frat House`,
+      do: () => (atLevel(12) ? $location`Wartime Frat House` : $location`The Orcish Frat House`),
       limit: { soft: 10 },
       choices: { 142: 3, 143: 3, 144: 3, 145: 1, 146: 3, 1433: 3 },
       outfit: () => {


### PR DESCRIPTION
Even after the recent fix, I was still getting occasional runs where the Outfit Hippy task was failing due to the location being unavailable. Tracking it down, it was running this task in some cases before level 12, so of course the wartime version was unavailable. It turns out if the player doesn't have Numberology, the ready check allows the task to go as soon as the island is unlocked, which depending on routing can happen much sooner than level 12.

Adjusting the location to use the war version if at level 12 and regular version otherwise fixes this issue. There are certainly other ways to do this fix, so let me know stylistically if you'd prefer something else – I could see a version where we break this into multiple simpler tasks.