### PR TITLE
Fix missing prepare superclass call in Sea path engine

### DIFF
--- a/src/paths/sea/engine.ts
+++ b/src/paths/sea/engine.ts
@@ -87,10 +87,11 @@ export class TheSeaEngine extends Engine {
     super.customize(task, outfit, combat, resources);
   }
 
-  override prepare(): void {
+  override prepare(task: ActiveTask): void {
     if (!have($effect`Fishy`)) {
       doFirstAvailableFishySource();
     }
+    super.prepare(task);
   }
 
   override createOutfit(task: ActiveTask): Outfit {


### PR DESCRIPTION
This subtle bug was causing prepare not to be called on tasks, preventing NC forces (and likely other resources) from working correctly. When overriding prepare, it needs to call the superclass prepare and pass the task along for those to work.